### PR TITLE
Arm stay silent - but encoding bug too?

### DIFF
--- a/concord232/api.py
+++ b/concord232/api.py
@@ -89,6 +89,8 @@ def command():
     if args.get('cmd') == 'arm':
         if args.get('type') == 'stay':
             CONTROLLER.arm_stay()
+        elif args.get('type') == 'stay-silent':
+            CONTROLLER.arm_stay_silent()
         elif args.get('type') == 'exit':
             CONTROLLER.arm_exit()
         else:

--- a/concord232/client.py
+++ b/concord232/client.py
@@ -24,7 +24,7 @@ class Client(object):
             return r.json()['partitions']
 
     def arm(self, armtype='auto'):
-        if armtype not in ['stay', 'exit', 'auto']:
+        if armtype not in ['stay', 'stay-silent', 'exit', 'auto']:
             raise Exception('Invalid arm type')
         r = self._session.get(
             self._url + '/command',

--- a/concord232/concord.py
+++ b/concord232/concord.py
@@ -229,7 +229,7 @@ def encode_message_to_ascii(bin_msg):
     s = ''
     for b in bin_msg:
         s += '%02x' % b
-    return s
+    return s.upper()
 
 def decode_message_from_ascii(ascii_msg):
     n = len(ascii_msg)

--- a/concord232/concord.py
+++ b/concord232/concord.py
@@ -578,6 +578,9 @@ class AlarmPanelInterface(object):
     def arm_stay(self):
         self.send_keypress([0x21])
 
+    def arm_stay_silent(self):
+        self.send_keypress([0x05, 0x21])
+
     def send_keys(self, keys, group):
         msg = []
         for k in keys:

--- a/concord232_client
+++ b/concord232_client
@@ -120,7 +120,8 @@ def main():
     clnt = client.Client(url)
     if args.command == 'list':
         do_list(clnt, args)
-    elif args.command in ['arm', 'arm-stay', 'arm-exit', 'arm-auto']:
+    elif args.command in ['arm', 'arm-stay', 'arm-stay-silent',
+                          'arm-exit', 'arm-auto']:
         do_arm(clnt, args)
     elif args.command == 'disarm':
         do_disarm(clnt, args)

--- a/concord232_client
+++ b/concord232_client
@@ -42,6 +42,8 @@ def do_list_partitions(clnt, args):
 def do_arm(clnt, args):
     if args.command == 'arm-stay':
         mode = 'stay'
+    elif args.command == 'arm-stay-silent':
+        mode = 'stay-silent'
     elif args.command == 'arm-exit':
         mode = 'exit'
     else:


### PR DESCRIPTION
The original point of this branch was to allow a new command:

concord232_client arm-stay-silent

which is the equivalent of pressing "5" "2" on the keypad.  I did implement this, but in the course of things discovered what seems to be a fairly major bug.  In the encoding from binary to ascii, python uses lowercase for the hex letters.  But the automation panel seems not to accept this, but rather only uppercase letters.  The protocol manual does seem to specify this, if not all that clearly, when they say:

"Only sixteen ASCII characters '0'...'9', 'A'...'F' are used to transfer data."

I am not sure if you are still interested in maintaining this, but I thought I'd make the pull request and see what you think.
