### PR TITLE
Rework arming interface to match features and terminology of Concord alarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,22 @@ $ concord232_client disarm --master 1234
 
 ## Arming with options
 
-Arm to stay silently
+Both stay (level 2) and away (level 3) alarms can take one of two
+options: silent arming, or instant arming.  Silent arming will not
+beep while the alarm is setting.  Instant arming has no delay.
+Clearly, this should only be used with away arming if you are already
+outside.
+
+Examples:
+
+Arm to stay with no delay
 ```
-$ concord232_client arm-stay-silent
+$ concord232_client arm-stay-instant
 ```
 
-Arm to away without delay
+Arm to away without beeps
 ```
-$ concord232_client arm-away-instant
+$ concord232_client arm-away-silent
 ```
 
 ## Home Assistant

--- a/README.md
+++ b/README.md
@@ -34,22 +34,33 @@ Once that is running, you should be able to do something like this::
  +------+-----------------+--------+--------+
 ```
 
- # Arm for stay with auto-bypass
- ```
+## Basic arming and disarming
+
+### Arm to stay (level 2)
+```
 $ concord232_client arm-stay
 ```
 
- # Arm for exit (requires tripping an entry zone)
- ```
-$ concord232_client arm-exit
+### Arm to away (level 3)
 ```
- # Auto-arm (no bypass, no entry zone trip required)
- ```
-$ concord232_client arm-auto
+$ concord232_client arm-away
 ```
- # Disarm
- ````
+
+### Disarm
+```
 $ concord232_client disarm --master 1234
+```
+
+## Arming options
+
+### Arm to stay silently
+```
+$ concord232_client arm-stay-silent
+```
+
+### Arm to stay without delay
+```
+$ concord232_client arm-stay-immediate
 ```
 
 ## Home Assistant

--- a/README.md
+++ b/README.md
@@ -36,29 +36,29 @@ Once that is running, you should be able to do something like this::
 
 ## Basic arming and disarming
 
-#### Arm to stay (level 2)
+Arm to stay (level 2)
 ```
 $ concord232_client arm-stay
 ```
 
-#### Arm to away (level 3)
+Arm to away (level 3)
 ```
 $ concord232_client arm-away
 ```
 
-#### Disarm
+Disarm
 ```
 $ concord232_client disarm --master 1234
 ```
 
-## Arming options
+## Arming with options
 
-#### Arm to stay silently
+Arm to stay silently
 ```
 $ concord232_client arm-stay-silent
 ```
 
-#### Arm to stay without delay
+Arm to stay without delay
 ```
 $ concord232_client arm-stay-immediate
 ```

--- a/README.md
+++ b/README.md
@@ -36,29 +36,29 @@ Once that is running, you should be able to do something like this::
 
 ## Basic arming and disarming
 
-### Arm to stay (level 2)
+#### Arm to stay (level 2)
 ```
 $ concord232_client arm-stay
 ```
 
-### Arm to away (level 3)
+#### Arm to away (level 3)
 ```
 $ concord232_client arm-away
 ```
 
-### Disarm
+#### Disarm
 ```
 $ concord232_client disarm --master 1234
 ```
 
 ## Arming options
 
-### Arm to stay silently
+#### Arm to stay silently
 ```
 $ concord232_client arm-stay-silent
 ```
 
-### Arm to stay without delay
+#### Arm to stay without delay
 ```
 $ concord232_client arm-stay-immediate
 ```

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Arm to stay silently
 $ concord232_client arm-stay-silent
 ```
 
-Arm to stay without delay
+Arm to away without delay
 ```
-$ concord232_client arm-stay-immediate
+$ concord232_client arm-away-instant
 ```
 
 ## Home Assistant

--- a/concord232/api.py
+++ b/concord232/api.py
@@ -87,14 +87,11 @@ def index_partitions():
 def command():
     args = flask.request.args
     if args.get('cmd') == 'arm':
-        if args.get('type') == 'stay':
-            CONTROLLER.arm_stay()
-        elif args.get('type') == 'stay-silent':
-            CONTROLLER.arm_stay_silent()
-        elif args.get('type') == 'exit':
-            CONTROLLER.arm_exit()
-        else:
-            CONTROLLER.arm_auto()
+        option = args.get('option')
+        if args.get('level') == 'stay':
+            CONTROLLER.arm_stay(option)
+        elif args.get('level') == 'away':
+            CONTROLLER.arm_away(option)
     elif args.get('cmd') == 'disarm':
         CONTROLLER.disarm(args.get('master_pin'))
     elif args.get('cmd') == 'keys':

--- a/concord232/client.py
+++ b/concord232/client.py
@@ -23,13 +23,12 @@ class Client(object):
         except TypeError:
             return r.json()['partitions']
 
-    def arm(self, armtype='auto'):
-        if armtype not in ['stay', 'stay-silent', 'exit', 'auto']:
-            raise Exception('Invalid arm type')
+    def arm(self, level, option):
         r = self._session.get(
             self._url + '/command',
             params={'cmd': 'arm',
-                    'type': armtype})
+                    'level': level,
+                    'option': option})
         return r.status_code == 200
 
     def disarm(self, master_pin):

--- a/concord232/concord.py
+++ b/concord232/concord.py
@@ -577,19 +577,19 @@ class AlarmPanelInterface(object):
         
     def arm_stay(self,option):
         if option == None:
-            self.send_keypress([0x21])
+            self.send_keypress([0x02])
         elif option == 'silent':
-            self.send_keypress([0x05, 0x21])
+            self.send_keypress([0x05, 0x02])
         elif option == 'instant':
-            self.send_keypress([0x21, 0x04])
+            self.send_keypress([0x02, 0x04])
 
     def arm_away(self,option):
         if option == None:
-            self.send_keypress([0x27])
+            self.send_keypress([0x03])
         elif option == 'silent':
-            self.send_keypress([0x05, 0x27])
+            self.send_keypress([0x05, 0x03])
         elif option == 'instant':
-            self.send_keypress([0x27, 0x04])
+            self.send_keypress([0x03, 0x04])
 
     def send_keys(self, keys, group):
         msg = []

--- a/concord232/concord.py
+++ b/concord232/concord.py
@@ -575,11 +575,21 @@ class AlarmPanelInterface(object):
         msg = build_keypress(keys, partition, area=0, no_check=True)
         self.enqueue_msg_for_tx(msg)
         
-    def arm_stay(self):
-        self.send_keypress([0x21])
+    def arm_stay(self,option):
+        if option == None:
+            self.send_keypress([0x21])
+        elif option == 'silent':
+            self.send_keypress([0x05, 0x21])
+        elif option == 'instant':
+            self.send_keypress([0x21, 0x04])
 
-    def arm_stay_silent(self):
-        self.send_keypress([0x05, 0x21])
+    def arm_away(self,option):
+        if option == None:
+            self.send_keypress([0x27])
+        elif option == 'silent':
+            self.send_keypress([0x05, 0x27])
+        elif option == 'instant':
+            self.send_keypress([0x27, 0x04])
 
     def send_keys(self, keys, group):
         msg = []

--- a/concord232_client
+++ b/concord232_client
@@ -39,17 +39,8 @@ def do_list_partitions(clnt, args):
         pprint.pprint(part)
 
 
-def do_arm(clnt, args):
-    if args.command == 'arm-stay':
-        mode = 'stay'
-    elif args.command == 'arm-stay-silent':
-        mode = 'stay-silent'
-    elif args.command == 'arm-exit':
-        mode = 'exit'
-    else:
-        mode = 'auto'
-    clnt.arm(mode)
-
+def do_arm(clnt, level, option):
+    clnt.arm(level, option)
 
 def do_disarm(clnt, args):
     if not args.master:
@@ -120,9 +111,13 @@ def main():
     clnt = client.Client(url)
     if args.command == 'list':
         do_list(clnt, args)
-    elif args.command in ['arm', 'arm-stay', 'arm-stay-silent',
-                          'arm-exit', 'arm-auto']:
-        do_arm(clnt, args)
+    elif args.command[0:3] == 'arm':
+        if args.command.count('-') == 2:
+            cmd, level, option = args.command.split('-')
+            do_arm(clnt, level, option)
+        else:
+            cmd, level = args.command.split('-')
+            do_arm(clnt, level, None)
     elif args.command == 'disarm':
         do_disarm(clnt, args)
     elif args.command == 'keys':

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='concord232',
-      version='0.14',
+      version='0.15',
       description='GE Concord 4 RS232 Serial Interface Library and Server',
       author='Jason Carter',
       author_email='jason@jason-carter.net',


### PR DESCRIPTION
Arming modes are now called "stay" (level 2) and "away" (level 3) to match terminology of Concord manual and keypads.

Silent and instant options are now accepted for stay and away arming:

concord232_client arm-stay-silent
concord232_client arm-stay-instant
concord232_client arm-away-silent
etc.

Updated README to reflect changes.

  Addresses issue #3 